### PR TITLE
Integrate in-toto (link attestations) with rebuilderd 

### DIFF
--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -339,6 +339,7 @@ pub struct Rebuild {
     pub status: BuildStatus,
     pub log: String,
     pub diffoscope: Option<String>,
+    pub attestation: Option<String>,
 }
 
 impl Rebuild {
@@ -347,6 +348,7 @@ impl Rebuild {
             status,
             log,
             diffoscope: None,
+            attestation: None,
         }
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -33,7 +33,7 @@ pub struct PkgRelease {
     pub build_id: Option<i32>,
     pub built_at: Option<NaiveDateTime>,
     pub has_diffoscope: bool,
-    pub attestation: Option<String>,
+    pub has_attestation: bool,
     pub next_retry: Option<NaiveDateTime>,
 }
 
@@ -50,7 +50,7 @@ impl PkgRelease {
             build_id: None,
             built_at: None,
             has_diffoscope: false,
-            attestation: None,
+            has_attestation: false,
             next_retry: None,
         }
     }

--- a/daemon/migrations/2021-08-06-184605_add_attestation/down.sql
+++ b/daemon/migrations/2021-08-06-184605_add_attestation/down.sql
@@ -1,0 +1,59 @@
+-- add attestation & drop has_attestation column in "packages"
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _packages_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    base_id INTEGER,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    build_id INTEGER,
+    built_at DATETIME,
+    has_diffoscope BOOLEAN NOT NULL,
+    attestation VARCHAR,
+    checksum VARCHAR,
+    retries INTEGER NOT NULL,
+    next_retry DATETIME,
+    CONSTRAINT packages_unique UNIQUE (name, distro, suite, architecture),
+    FOREIGN KEY(base_id) REFERENCES pkgbases(id),
+    FOREIGN KEY(build_id) REFERENCES builds(id)
+);
+
+INSERT INTO _packages_new (id, base_id, name, version, status, distro, suite, architecture, url, build_id, built_at, has_diffoscope, attestation, checksum, retries, next_retry)
+    SELECT id, base_id, name, version, status, distro, suite, architecture, url, build_id, built_at, false, NULL, checksum, retries, next_retry
+    FROM packages;
+
+-- copy all attestations values from "build" to "packages" table
+UPDATE _packages_new
+  SET attestation=(
+        SELECT attestation
+        FROM builds
+        WHERE builds.id = _packages_new.build_id
+    );
+
+DROP TABLE packages;
+ALTER TABLE _packages_new RENAME TO packages;
+
+PRAGMA foreign_keys=on;
+
+-- drop attestation column in "build"
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _builds_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    diffoscope TEXT,
+    build_log BLOB NOT NULL
+);
+
+INSERT INTO _builds_new (id, diffoscope, build_log)
+    SELECT id, diffoscope, build_log
+    FROM builds;
+
+DROP TABLE builds;
+ALTER TABLE _builds_new RENAME TO builds;
+
+PRAGMA foreign_keys=on;

--- a/daemon/migrations/2021-08-06-184605_add_attestation/up.sql
+++ b/daemon/migrations/2021-08-06-184605_add_attestation/up.sql
@@ -1,0 +1,40 @@
+-- add attestation field to "build" table
+ALTER TABLE builds
+ADD attestation VARCHAR;
+
+-- drop attestation column, add has_attestation field to "packages" table
+PRAGMA foreign_keys=off;
+
+CREATE TABLE _packages_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    base_id INTEGER,
+    name VARCHAR NOT NULL,
+    version VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    distro VARCHAR NOT NULL,
+    suite VARCHAR NOT NULL,
+    architecture VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    build_id INTEGER,
+    built_at DATETIME,
+    has_diffoscope BOOLEAN NOT NULL,
+    has_attestation BOOLEAN NOT NULL,
+    checksum VARCHAR,
+    retries INTEGER NOT NULL,
+    next_retry DATETIME,
+    CONSTRAINT packages_unique UNIQUE (name, distro, suite, architecture),
+    FOREIGN KEY(base_id) REFERENCES pkgbases(id),
+    FOREIGN KEY(build_id) REFERENCES builds(id)
+);
+
+INSERT INTO _packages_new (id, base_id, name, version, status, distro, suite, architecture, url, build_id, built_at, has_diffoscope, has_attestation, checksum, retries, next_retry)
+    SELECT id, base_id, name, version, status, distro, suite, architecture, url, build_id, built_at, false, false, checksum, retries, next_retry
+    FROM packages;
+
+DROP TABLE packages;
+ALTER TABLE _packages_new RENAME TO packages;
+
+PRAGMA foreign_keys=on;
+
+-- initialize new has_attestation field
+update packages set has_attestation=true where build_id in (select id from builds where attestation is not null);

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -79,6 +79,7 @@ pub async fn run_config(config: Config) -> Result<()> {
             .service(api::ping_build)
             .service(api::get_build_log)
             .service(api::get_diffoscope)
+            .service(api::get_attestation)
             .service(api::get_dashboard)
             .service(
                 web::resource("/api/v0/build/report").app_data(

--- a/daemon/src/models/build.rs
+++ b/daemon/src/models/build.rs
@@ -9,6 +9,7 @@ use rebuilderd_common::errors::*;
 pub struct Build {
     pub id: i32,
     pub diffoscope: Option<String>,
+    pub attestation: Option<String>,
     pub build_log: Vec<u8>,
 }
 
@@ -26,6 +27,7 @@ impl Build {
 #[table_name="builds"]
 pub struct NewBuild {
     pub diffoscope: Option<String>,
+    pub attestation: Option<String>,
     pub build_log: Vec<u8>,
 }
 
@@ -52,6 +54,7 @@ impl NewBuild {
     pub fn from_api(report: &BuildReport) -> NewBuild {
         NewBuild {
             diffoscope: report.rebuild.diffoscope.clone(),
+            attestation: report.rebuild.attestation.clone(),
             build_log: report.rebuild.log.as_bytes().to_vec(),
         }
     }

--- a/daemon/src/models/package.rs
+++ b/daemon/src/models/package.rs
@@ -21,7 +21,7 @@ pub struct Package {
     pub build_id: Option<i32>,
     pub built_at: Option<NaiveDateTime>,
     pub has_diffoscope: bool,
-    pub attestation: Option<String>,
+    pub has_attestation: bool,
     pub checksum: Option<String>,
     pub retries: i32,
     pub next_retry: Option<NaiveDateTime>,
@@ -134,7 +134,7 @@ impl Package {
             _ => Status::Bad.to_string(),
         };
         self.built_at = Some(Utc::now().naive_utc());
-
+        self.has_attestation = rebuild.attestation.is_some();
         diesel::update(packages::table
                 .filter(id.eq(self.id))
                 .filter(version.eq(&self.version))
@@ -184,7 +184,7 @@ impl Package {
             build_id: self.build_id,
             built_at: self.built_at,
             has_diffoscope: self.has_diffoscope,
-            attestation: self.attestation,
+            has_attestation: self.has_attestation,
             next_retry: self.next_retry,
         })
     }
@@ -204,7 +204,7 @@ pub struct NewPackage {
     pub build_id: Option<i32>,
     pub built_at: Option<NaiveDateTime>,
     pub has_diffoscope: bool,
-    pub attestation: Option<String>,
+    pub has_attestation: bool,
     pub checksum: Option<String>,
     pub retries: i32,
     pub next_retry: Option<NaiveDateTime>,
@@ -238,7 +238,7 @@ impl NewPackage {
             build_id: None,
             built_at: None,
             has_diffoscope: false,
-            attestation: None,
+            has_attestation: false,
             checksum: None,
             retries: 0,
             next_retry: None,

--- a/daemon/src/schema.rs
+++ b/daemon/src/schema.rs
@@ -2,6 +2,7 @@ table! {
     builds (id) {
         id -> Integer,
         diffoscope -> Nullable<Text>,
+        attestation -> Nullable<Text>,
         build_log -> Binary,
     }
 }
@@ -20,7 +21,7 @@ table! {
         build_id -> Nullable<Integer>,
         built_at -> Nullable<Timestamp>,
         has_diffoscope -> Bool,
-        attestation -> Nullable<Text>,
+        has_attestation -> Bool,
         checksum -> Nullable<Text>,
         retries -> Integer,
         next_retry -> Nullable<Timestamp>,

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -202,6 +202,7 @@ async fn main() -> Result<()> {
             diffoscope: None,
             log: String::new(),
             status: BuildStatus::Bad,
+            attestation: None,
         };
         let report = BuildReport {
             queue,
@@ -279,6 +280,7 @@ async fn main() -> Result<()> {
             diffoscope: None,
             log: String::new(),
             status: BuildStatus::Good,
+            attestation: None,
         };
         let report = BuildReport {
             queue,

--- a/tools/src/schedule/archlinux.rs
+++ b/tools/src/schedule/archlinux.rs
@@ -135,6 +135,7 @@ pub async fn sync(sync: &PkgsSync) -> Result<Vec<PkgGroup>> {
     let client = reqwest::Client::new();
 
     let mut bases: HashMap<_, PkgGroup> = HashMap::new();
+
     for arch in &sync.architectures {
         let db = mirror_to_url(source, &sync.suite, arch, &format!("{}.db", sync.suite))?;
         let bytes = fetch_url_or_path(&client, &db)

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -25,6 +25,7 @@ sodiumoxide = { version="0.2.5", features=["use-pkg-config"] }
 base64 = "0.13"
 toml = "0.5.6"
 serde = { version="1.0", features=["derive"] }
+serde_json = "1"
 reqwest = { version="0.11", features = ["stream"] }
 tempfile = "3.1.0"
 url = "2.1.1"
@@ -32,3 +33,4 @@ tokio = { version="1", features=["macros", "rt-multi-thread", "fs", "io-util", "
 futures-util = "0.3.7"
 futures = "0.3.7"
 nix = "0.22"
+in-toto = "0.1.1"

--- a/worker/src/auth.rs
+++ b/worker/src/auth.rs
@@ -1,3 +1,4 @@
+use in_toto::crypto::{KeyType, PrivateKey, SignatureScheme};
 use rebuilderd_common::api::Client;
 use rebuilderd_common::config::ConfigFile;
 use rebuilderd_common::errors::*;
@@ -6,16 +7,16 @@ use std::path::Path;
 use std::fs::OpenOptions;
 use std::os::unix::fs::OpenOptionsExt;
 use std::io::prelude::*;
-use sodiumoxide::crypto::sign;
 
 pub struct Profile {
-    key: String,
+    pub pubkey: String,
+    pub privkey: PrivateKey,
 }
 
 impl Profile {
     pub fn new_client(&self, config: ConfigFile, endpoint: String, signup_secret: Option<String>, auth_cookie: Option<String>) -> Client {
         let mut client = Client::new(config, Some(endpoint));
-        client.worker_key(self.key.clone());
+        client.worker_key(self.pubkey.clone());
         if let Some(signup_secret) = signup_secret {
             client.signup_secret(signup_secret);
         } else if let Some(auth_cookie) = auth_cookie {
@@ -25,23 +26,19 @@ impl Profile {
     }
 }
 
+#[inline]
 pub fn load() -> Result<Profile> {
-    let key = load_key("rebuilder.key")?;
-
-    Ok(Profile {
-        key,
-    })
+    load_key("rebuilder.key")
 }
 
-fn load_key<P: AsRef<Path>>(path: P) -> Result<String> {
+fn load_key<P: AsRef<Path>>(path: P) -> Result<Profile> {
     let path = path.as_ref();
 
-    let sk = if path.exists() {
+    let privkey = if path.exists() {
         let content = fs::read(path)?;
-        sign::SecretKey::from_slice(&content)
-            .ok_or_else(|| format_err!("failed to load secret key"))?
+        PrivateKey::from_pkcs8(&content, SignatureScheme::Ed25519)?
     } else {
-        let (_, sk) = sign::gen_keypair();
+        let sk = PrivateKey::new(KeyType::Ed25519)?;
 
         let mut file = OpenOptions::new()
             .mode(0o640)
@@ -50,10 +47,14 @@ fn load_key<P: AsRef<Path>>(path: P) -> Result<String> {
             .open(path)?;
         file.write_all(&sk[..])?;
 
-        sk
+        PrivateKey::from_pkcs8(&sk, SignatureScheme::Ed25519)?
     };
 
-    let pk = sk.public_key();
-    let key = base64::encode(&pk[..]);
-    Ok(key)
+    let pk = privkey.public();
+    let pubkey = base64::encode(pk.as_bytes());
+
+    Ok(Profile {
+        pubkey,
+        privkey,
+    })
 }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -2,6 +2,7 @@
 
 use crate::rebuild::Context;
 use env_logger::Env;
+use in_toto::crypto::PrivateKey;
 use structopt::StructOpt;
 use structopt::clap::AppSettings;
 use rebuilderd_common::Distro;
@@ -69,7 +70,7 @@ struct Diffoscope {
     pub b: PathBuf,
 }
 
-async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Distro, item: &QueueItem, config: &config::ConfigFile) -> Result<Rebuild> {
+async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Distro, privkey: &'a PrivateKey, item: &QueueItem, config: &config::ConfigFile) -> Result<Rebuild> {
     let input = item.package.url.to_string();
 
     let ctx = Context {
@@ -77,6 +78,7 @@ async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Dis
         script_location: None,
         build: config.build.clone(),
         diffoscope: config.diffoscope.clone(),
+        privkey,
     };
 
     let mut rebuild = Box::pin(rebuild::rebuild(&ctx, &input));
@@ -94,7 +96,7 @@ async fn spawn_rebuilder_script_with_heartbeat<'a>(client: &Client, distro: &Dis
     }
 }
 
-async fn rebuild(client: &Client, config: &config::ConfigFile) -> Result<()> {
+async fn rebuild(client: &Client, privkey: &PrivateKey, config: &config::ConfigFile) -> Result<()> {
     info!("Requesting work from rebuilderd...");
     match client.pop_queue(&WorkQuery {}).await? {
         JobAssignment::Nothing => {
@@ -104,7 +106,7 @@ async fn rebuild(client: &Client, config: &config::ConfigFile) -> Result<()> {
         JobAssignment::Rebuild(rb) => {
             info!("Starting rebuild of {:?} {:?}",  rb.package.name, rb.package.version);
             let distro = rb.package.distro.parse::<Distro>()?;
-            let rebuild = match spawn_rebuilder_script_with_heartbeat(client, &distro, &rb, config).await {
+            let rebuild = match spawn_rebuilder_script_with_heartbeat(&client, &distro, &privkey, &rb, config).await {
                 Ok(res) => {
                     if res.status == BuildStatus::Good {
                         info!("Package successfully verified");
@@ -131,9 +133,9 @@ async fn rebuild(client: &Client, config: &config::ConfigFile) -> Result<()> {
     Ok(())
 }
 
-async fn run_worker_loop(client: &Client, config: &config::ConfigFile) -> Result<()> {
+async fn run_worker_loop(client: &Client, privkey: &PrivateKey, config: &config::ConfigFile) -> Result<()> {
     loop {
-        if let Err(err) = rebuild(client, config).await {
+        if let Err(err) = rebuild(client, privkey, config).await {
             error!("Unexpected error, sleeping for {}s: {:#}", API_ERROR_DELAY, err);
             time::sleep(Duration::from_secs(API_ERROR_DELAY)).await;
         }
@@ -167,6 +169,7 @@ async fn main() -> Result<()> {
         setup::run(&name)
             .context("Failed to setup worker")?;
     }
+    let profile = auth::load()?;
 
     match args.subcommand {
         SubCommand::Connect(connect) => {
@@ -179,9 +182,8 @@ async fn main() -> Result<()> {
                     .ok_or_else(|| format_err!("No endpoint configured"))?
             };
 
-            let profile = auth::load()?;
             let client = profile.new_client(system_config, endpoint, config.signup_secret.clone(), cookie);
-            run_worker_loop(&client, &config).await?;
+            run_worker_loop(&client, &profile.privkey, &config).await?;
         },
         SubCommand::Build(build) => {
             // this is only really for debugging
@@ -195,6 +197,7 @@ async fn main() -> Result<()> {
                 script_location: build.script_location.as_ref(),
                 build: config::Build::default(),
                 diffoscope,
+                privkey: &profile.privkey,
             }, &build.input).await?;
 
             debug!("rebuild result object is {:?}", res);

--- a/worker/src/rebuild.rs
+++ b/worker/src/rebuild.rs
@@ -2,10 +2,12 @@ use crate::config;
 use crate::diffoscope::diffoscope;
 use crate::download::download;
 use crate::proc;
-use rebuilderd_common::Distro;
-use rebuilderd_common::api::{Rebuild, BuildStatus};
+use in_toto::crypto::PrivateKey;
+use in_toto::runlib::in_toto_run;
+use rebuilderd_common::api::{BuildStatus, Rebuild};
+use rebuilderd_common::errors::Context as _;
 use rebuilderd_common::errors::*;
-use rebuilderd_common::errors::{Context as _};
+use rebuilderd_common::Distro;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
@@ -20,6 +22,7 @@ pub struct Context<'a> {
     pub script_location: Option<&'a PathBuf>,
     pub build: config::Build,
     pub diffoscope: config::Diffoscope,
+    pub privkey: &'a PrivateKey,
 }
 
 fn locate_script(distro: &Distro, script_location: Option<PathBuf>) -> Result<PathBuf> {
@@ -128,12 +131,33 @@ pub async fn rebuild(ctx: &Context<'_>, url: &str) -> Result<Rebuild> {
 
     // process result
     let output_path = out_dir.join(&filename);
+
+    info!("Generating signed link");
+
+
+    let signed_link = in_toto_run(
+        &format!("rebuild {}", filename.to_str().unwrap()),
+        None,
+        &[input_path.to_str().unwrap()],
+        &[output_path.to_str().unwrap()],
+        &[],
+        Some(ctx.privkey),
+        Some(&["sha512", "sha256"]),
+    )?;
+
+    info!("Signed link generated");
+
     if !output_path.exists() {
         info!("Build failed, no output artifact found at {:?}", output_path);
         Ok(Rebuild::new(BuildStatus::Bad, log))
     } else if compare_files(&input_path, &output_path).await? {
         info!("Files are identical, marking as GOOD");
-        Ok(Rebuild::new(BuildStatus::Good, log))
+        let mut res = Rebuild::new(BuildStatus::Good, log);
+
+        let attestation = serde_json::to_string(&signed_link).context("Failed to serialize attestation")?;
+        res.attestation = Some(attestation);
+
+        Ok(res)
     } else {
         info!("Build successful but artifacts differ");
         let mut res = Rebuild::new(BuildStatus::Bad, log);
@@ -155,7 +179,8 @@ async fn verify(ctx: &Context<'_>, out_dir: &Path, input_path: &Path) -> Result<
         Cow::Borrowed(script)
     } else {
         let script = locate_script(ctx.distro, None)
-            .with_context(|| anyhow!("Failed to locate rebuild backend for distro={}", ctx.distro))?;
+            .with_context(|| {anyhow!("Failed to locate rebuild backend for distro={}", ctx.distro)
+        })?;
         Cow::Owned(script)
     };
 


### PR DESCRIPTION
**The following PR is part of the Google Summer of Code 2021 program.**

The in-toto GSoC project is to **develop in-toto-rs capabilities to support rebuilderd** (Issue https://github.com/in-toto/in-toto-rs/issues/4), which includes two parts:
1. Add `runlib.rs`; implement link generation using `in_toto_run`.
2. Use `in_toto_run` and link generation within rebuilderd.

This PR addresses part 2.

**Features**
- [x] Make relevant changes to `rebuilderd.db` with SQL migrations (add `has_attestation` field to `packages`, remove `attestation` field from `packages`, and add `attestation` to `builds` to store link attestation)
- [x] Update models to reflect db changes
- [x] Integrate `in_toto_run` function to run and generate link attestation based on rebuild with contextual link name
- [x] Store `attestation` and `has_attestation` in DB when `Build` is good
- [x] Create API endpoint for rebuilderd to get link attestation data from db.